### PR TITLE
Make keys rebindable

### DIFF
--- a/Controls.cs
+++ b/Controls.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using UnityEngine;
+using HarmonyLib;
+using TMPro;
+
+// Stores constants to use across all patches and precaches them
+public static class Controls
+{
+    public static readonly string[] newControls = new string[] { "Open chat", "Close chat", "See players" };
+    public static readonly int[] defaultValues = new int[] { (int)KeyCode.Return, (int)KeyCode.Escape, (int)KeyCode.Tab };
+
+    public static KeyCode[] keys = new KeyCode[] { KeyCode.Return, KeyCode.Escape, KeyCode.Tab };
+
+    public const int OPEN_CHAT = 0;
+    public const int CLOSE_CHAT = 1;
+    public const int SEE_PLAYER = 2;
+}
+
+// Adding GameObject of controls and their value in ControlBinder.texts, also sets default values of PlayerPrefs if it missing
+[HarmonyPatch(typeof(ControlBinder), "Start")]
+internal static class ControlsGoCreator
+{
+    private static void Postfix(ControlBinder __instance)
+    {
+        GameObject fieldOrigianl = __instance.texts["Slowmo"].gameObject;
+        GameObject labelOrigianl = GameObject.Find("Canvas/Settings/ControlSettings/MainName (13)");
+        if (null == fieldOrigianl || null == labelOrigianl)
+        {
+            UnityEngine.Debug.LogError("[GunsawMP] Unable to create controls");
+            return;
+        }
+        // Creating clone of original fields, because new fields will get set as a children of original
+        //thus if we clone original, we clone childrens too
+        GameObject fieldBase = UnityEngine.Object.Instantiate(fieldOrigianl);
+        GameObject labelBase = UnityEngine.Object.Instantiate(labelOrigianl);
+
+        for (int i = 0; i < Controls.newControls.Length; i++)
+        {
+            Transform newField = UnityEngine.Object.Instantiate(fieldBase).transform;
+            Vector3 newOffset = new Vector3(0, -50 + -50 * i);
+            newField.SetParent(fieldOrigianl.transform);
+            newField.localScale = Vector3.one;
+            newField.localPosition = newOffset;
+            newField.name = Controls.newControls[i];
+            __instance.texts.Add(Controls.newControls[i], newField.GetComponent<TextMeshProUGUI>());
+
+            Transform newLabel = UnityEngine.Object.Instantiate(labelBase).transform;
+            newLabel.SetParent(labelOrigianl.transform);
+            newLabel.localScale = Vector3.one;
+            newLabel.localPosition = newOffset;
+            newLabel.GetComponent<TextMeshProUGUI>().text = Controls.newControls[i];
+        }
+
+        UnityEngine.Object.Destroy(fieldBase);
+        UnityEngine.Object.Destroy(labelBase);
+
+        if (!PlayerPrefs.HasKey(Controls.newControls[0]))
+            ControlsResetPatch.ResetCustomKeyCodes(__instance);
+
+        __instance.UpdateBindings();
+    }
+}
+
+// Set default values
+[HarmonyPatch(typeof(ControlBinder), "ResetBinds")]
+internal static class ControlsResetPatch
+{
+    [HarmonyPrefix]
+    public static void ResetCustomKeyCodes(ControlBinder __instance)
+    {
+        for (int i = 0; i < Controls.newControls.Length; i++)
+            PlayerPrefs.SetInt(Controls.newControls[i], Controls.defaultValues[i]);
+    }
+}
+
+// Add instances of keys into PlayerScript.keys and Controls.keys
+[HarmonyPatch(typeof(PlayerScript), "Awake")]
+internal static class ControlsAdder
+{
+    private static void Postfix(PlayerScript __instance)
+    {
+        for (int i = 0; i < Controls.newControls.Length; i++)
+        {
+            KeyCode code = (KeyCode)PlayerPrefs.GetInt(Controls.newControls[i]);
+            __instance.keys.Add(Controls.newControls[i], code);
+            Controls.keys[i] = code;
+        }
+    }
+}

--- a/GunsawMultiplayer.csproj
+++ b/GunsawMultiplayer.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>GunsawMultiplayer</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.3" PrivateAssets="all" />
     <Reference Include="BepInEx">
       <HintPath>$(GameDirectory)/BepInEx/core/BepInEx.dll</HintPath>
       <Private>false</Private>
@@ -69,7 +70,7 @@
       <HintPath>$(GameDirectory)/Gunsaw_Data/Managed/Unity.TextMeshPro.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp">
+    <Reference Include="Assembly-CSharp" Publicize="true">
       <HintPath>$(GameDirectory)/Gunsaw_Data/Managed/Assembly-CSharp.dll</HintPath>
       <Private>false</Private>
     </Reference>

--- a/MultiplayerHud.cs
+++ b/MultiplayerHud.cs
@@ -83,8 +83,8 @@ internal sealed class MultiplayerHud : MonoBehaviour
         }
         if (networkStatsVisible) UpdateNetworkStatsWidget();
         else if (networkStatsObject != null) DestroyNetworkStatsWidget();
-        var enter = Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter);
-        if (!chatOpen && enter)
+        bool chatOpenKeyDown = Input.GetKeyDown(Controls.keys[Controls.OPEN_CHAT]);
+        if (!chatOpen && chatOpenKeyDown)
         {
             chatOpen = true;
             IsTyping = true;
@@ -94,14 +94,14 @@ internal sealed class MultiplayerHud : MonoBehaviour
             return;
         }
         if (!chatOpen) return;
-        if (waitForChatOpenKeyRelease && !Input.GetKey(KeyCode.Return) && !Input.GetKey(KeyCode.KeypadEnter))
+        if (waitForChatOpenKeyRelease && !Input.GetKey(Controls.keys[Controls.OPEN_CHAT]))
             waitForChatOpenKeyRelease = false;
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (Input.GetKeyDown(Controls.keys[Controls.CLOSE_CHAT]))
         {
             CloseChat();
             return;
         }
-        if (!waitForChatOpenKeyRelease && enter)
+        if (!waitForChatOpenKeyRelease && chatOpenKeyDown)
             Submit();
     }
 

--- a/MultiplayerHudUi.cs
+++ b/MultiplayerHudUi.cs
@@ -24,7 +24,7 @@ internal sealed class MultiplayerHudUi : MonoBehaviour
         if (root == null) return;
         root.SetActive(true);
         hostPanel.SetActive(MultiplayerSession.IsHosting);
-        playersPanel.SetActive(Input.GetKey(KeyCode.Tab) && !hud.ChatOpen);
+        playersPanel.SetActive(Input.GetKey(Controls.keys[Controls.SEE_PLAYER]) && !hud.ChatOpen);
         chatPanel.SetActive(MultiplayerSession.IsConnected);
         hostText.text = "HOSTING  " + MultiplayerSession.PlayerCount + "/" + MultiplayerSession.MaxPlayers + " PLAYERS";
         if (playersPanel.activeSelf) UpdatePlayers();


### PR DESCRIPTION
Make open chat, close chat and see players keys rebindable
<img width="2560" height="1440" alt="Screenshot_20260726_090134" src="https://github.com/user-attachments/assets/2fea661f-c5fc-49a8-8469-0ef94a007de5" />
It sets only custom keys to default on first startup with multiplayer mod, and default binding is the same
Enter still always sends chat message
I had to remove option to show chat on Keypad enter as you can not bind multiple keys on same button
