### PR TITLE
Prevent gameplay keys being registred when typing in chat

### DIFF
--- a/MultiplayerHud.cs
+++ b/MultiplayerHud.cs
@@ -100,7 +100,7 @@ internal sealed class MultiplayerHud : MonoBehaviour
         if (waitForChatOpenKeyRelease && !Input.GetKey(Controls.keys[Controls.OPEN_CHAT]))
             waitForChatOpenKeyRelease = false;
         if (Input.GetKeyDown(Controls.keys[Controls.CLOSE_CHAT]))
-        {
+        { // Lets hope that bind is not typable
             CloseChat();
             return;
         }
@@ -365,3 +365,51 @@ internal sealed class MultiplayerHud : MonoBehaviour
         internal string Clock;
     }
 }
+
+// Prevents game ui from reading anything when chat is open
+[HarmonyPatch(typeof(Input))]
+internal static class ChatOpenHandler
+{
+    [HarmonyPatch(nameof(Input.GetKey), typeof(KeyCode))]
+    [HarmonyPrefix]
+    private static bool PrefixGetKey(ref bool __result, KeyCode key)
+    {
+        if (IsChatOpenAndKeyIsTypable(key))
+        {
+            __result = false;
+            return false;
+        }
+        return true;
+    }
+
+    [HarmonyPatch(nameof(Input.GetKeyDown), typeof(KeyCode))]
+    [HarmonyPrefix]
+    private static bool PrefixGetKeyDown(ref bool __result, KeyCode key)
+    {
+        if (IsChatOpenAndKeyIsTypable(key))
+        {
+            __result = false;
+            return false;
+        }
+        return true;
+    }
+
+    [HarmonyPatch(nameof(Input.GetKeyUp), typeof(KeyCode))]
+    [HarmonyPrefix]
+    private static bool PrefixGetKeyUp(ref bool __result, KeyCode key)
+    {
+        if (IsChatOpenAndKeyIsTypable(key))
+        {
+            __result = false;
+            return false;
+        }
+        return true;
+    }
+
+    private static bool IsChatOpenAndKeyIsTypable(KeyCode key)
+    {
+        return (null != MultiplayerHud.Instance && MultiplayerHud.Instance.ChatOpen) &&
+            ((KeyCode.Space == key) || (KeyCode.A <= key && KeyCode.Z >= key) || (KeyCode.Alpha0 <= key && KeyCode.Alpha9 >= key));
+    }
+}
+


### PR DESCRIPTION
this, self-explain
if player binds typable letter to close chat, chat would be impossible to close, lol, you still can click reset binds tho