### PR TITLE
Improve host FPS and reduce network RX/TX by taking world snapshots less often when not needed

### DIFF
--- a/WorldReplication.cs
+++ b/WorldReplication.cs
@@ -138,6 +138,7 @@ internal sealed class WorldReplication : MonoBehaviour
     private string lastMissingInputId = "";
     private string lastRejectedInputId = "";
     private string lastMissingSnapshotId = "";
+    private float clientFastSerializeState = 0f;
 
     internal int TotalPropCount
     {
@@ -368,8 +369,9 @@ internal sealed class WorldReplication : MonoBehaviour
             received.Clear();
             MultiplayerPerformance.AddPhase(MultiplayerPerformancePhase.WorldStateApply, applyStarted);
         }
-        if (Time.unscaledTime >= nextSnapshot)
+        if (clientFastSerializeState > 0f || Time.unscaledTime >= nextSnapshot)
         {
+            clientFastSerializeState -= Time.fixedDeltaTime;
             nextSnapshot = Time.unscaledTime + SnapshotInterval;
             MultiplayerSession.SendWorldInput(SerializePushes());
             MultiplayerSession.SendWorldDamage(SerializeDamage());
@@ -1474,6 +1476,7 @@ internal sealed class WorldReplication : MonoBehaviour
     private void QueueBodyState(Rigidbody2D body)
     {
         locallyControlledUntil[body] = Time.unscaledTime + 0.35f;
+        clientFastSerializeState = 0.35f; // isnt that suppsoed to be ClientAuthorityGrace?
         body.simulated = true;
         body.bodyType = RigidbodyType2D.Dynamic;
         body.WakeUp();
@@ -1500,6 +1503,7 @@ internal sealed class WorldReplication : MonoBehaviour
         }
         foreach (var body in renew)
             locallyControlledUntil[body] = now + ClientAuthorityGrace;
+        clientFastSerializeState = ClientAuthorityGrace;
     }
 
     private static ClientBodyState CaptureBodyState(Rigidbody2D body)
@@ -1523,6 +1527,7 @@ internal sealed class WorldReplication : MonoBehaviour
         if (nextDamage.TryGetValue(id, out allowedAt) && Time.unscaledTime < allowedAt) return;
         nextDamage[id] = Time.unscaledTime + 0.10f;
         damage[id] = Mathf.Min(100f, amount);
+        clientFastSerializeState = Mathf.Max(clientFastSerializeState, 0.01f);
     }
 
     internal void QueueLevitated(Rigidbody2D body)

--- a/WorldReplication.cs
+++ b/WorldReplication.cs
@@ -2431,6 +2431,7 @@ internal sealed class WorldReplication : MonoBehaviour
             (nextButtonActivation.TryGetValue(id, out allowedAt) && Time.unscaledTime < allowedAt)) return;
         nextButtonActivation[id] = Time.unscaledTime + 0.15f;
         button.Activated();
+        nextSnapshot = 0f; // Sending new world state
     }
 
     private void ApplyButtonState(string id, bool exists, uint activations)

--- a/WorldReplication.cs
+++ b/WorldReplication.cs
@@ -21,7 +21,7 @@ internal sealed class WorldReplication : MonoBehaviour
     internal const byte VehicleDamage = 7;
     internal const byte DroneDamage = 8;
 
-    private const float SnapshotInterval = 1f / 50f;
+    private const float SnapshotInterval = 1f / 5f;
     private const float FullSnapshotInterval = 1f;
     private const float ClientAuthorityGrace = 0.35f;
     private const bool DiagnosticsEnabled = false;


### PR DESCRIPTION
Spend a lot of time in monoprofiler and founded that SerializeWorld() destroyes FPS
Reduce snapshot interval from 50 times a second to 5 improves host FPS
Made a lot of tests doesnt seem to affect gameplay, only minor thing i saw boxes sometimes does a little jump 5 times a sec (we can fix it later). Or actually, now host have more time to sync NPCs
Also made it so it immedently sends new world state after button push to remove button lag that would been present

Hard to tell how exactly much it helps, as (ironicly) profiler itself reduces FPS very drasticly
I have a somewhat consistent benchmark on map foundry by MrCrawler, and, after 10 minutes of playing with client (another instance on same computer) i previously had 30 fps, now im getting 40 fps
For context: my CPU is i7-10700k
ps another thing i saw in profiler that WorldReplication.CaptureLocalContacts() takes a lot of time on client