### PR TITLE
Fix door expie bug

### DIFF
--- a/NpcReplication.cs
+++ b/NpcReplication.cs
@@ -2212,7 +2212,8 @@ internal sealed class NpcReplication : MonoBehaviour
     private static bool IsCoreNpcRenderer(SpriteRenderer renderer)
     {
         return renderer.GetComponentInParent<LimbScript>() != null ||
-               renderer.GetComponentInParent<WeaponScript>() != null;
+               renderer.GetComponentInParent<WeaponScript>() != null ||
+               renderer.GetComponentInParent<AnimatedBodyScript>() != null;
     }
 
     private static void WriteColor32(BinaryWriter writer, Color color)


### PR DESCRIPTION
Fix a bizzare door expie bug that caused an door with experiment head to appear on client side.
The reasson behind it? AnimLimbs have a SpriteRenderer for some fucking reasson
I excluded it from trying to sync it seems to fixed that
Attached screenshots that i took in unity explorer when troubleshooting
<img width="2560" height="1440" alt="Screenshot_20260728_091908" src="https://github.com/user-attachments/assets/5a94bf4d-9bde-44a1-8d87-457433a7c401" />
<img width="2560" height="1440" alt="Screenshot_20260728_092347" src="https://github.com/user-attachments/assets/3ae0b21e-c696-4191-9b6c-1be2a73491b2" />
<img width="2560" height="1440" alt="Screenshot_20260728_165051" src="https://github.com/user-attachments/assets/f2060231-c05a-47b6-b55d-7a6a95f5e3e5" />
